### PR TITLE
Fix loss of htmlClass (e.g. highlight) for graph rects with zero scale

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -1070,7 +1070,7 @@ var CalHeatMap = function() {
 				var htmlClass = self.getHighlightClassName(d.t);
 
 				if (self.legendScale === null) {
-					htmlClass = " graph-rect";
+					htmlClass += " graph-rect";
 				}
 
 				if (d.v !== null) {


### PR DESCRIPTION
Fixes a typo from f5a628dd that prevents highlight/now from showing with some cells.
