### PR TITLE
Corrected a Dead Link resulting from typo in the documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ cal.init({
 </code></pre>
 
 			<p>
-			The data must be formatted according to the expected <a href="$data-format">data format</a>. In case it's not possible, you should first set the correct <a href="#dataType"><code>dataType</code></a> if it's not returning a json response, then use the <a href="#afterLoadData"><code>afterLoadData()</code></a> to transform the data into the <a href="#data-format">expected format</a>.
+			The data must be formatted according to the expected <a href="#data-format">data format</a>. In case it's not possible, you should first set the correct <a href="#dataType"><code>dataType</code></a> if it's not returning a json response, then use the <a href="#afterLoadData"><code>afterLoadData()</code></a> to transform the data into the <a href="#data-format">expected format</a>.
 			</p>
 
 			<p>4 template strings are available to limit the scope of data returned by the API</p>


### PR DESCRIPTION
I was just reading the documentation and came across the dead link, and noticed it was a typo.  Here's the fix.  Thanks for the tool!
