### PR TITLE
Add version to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "d3js",
     "heat map"
   ],
+  "version": "3.3.8",
   "main": ["./cal-heatmap.js", "./cal-heatmap.css"],
   "dependencies": {
     "d3": ">= v3.0.6"


### PR DESCRIPTION
bower.json should include the version to avoid problems with some versions of bower.
