### PR TITLE
Fixing highlighting for week subdomain

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -1879,6 +1879,8 @@ CalHeatMap.prototype = {
 				dateA.getDate() === dateB.getDate();
 		case "x_week":
 		case "week":
+			return dateA.getFullYear() === dateB.getFullYear() &&
+				this.getWeekNumber(dateA) === this.getWeekNumber(dateB);
 		case "x_month":
 		case "month":
 			return dateA.getFullYear() === dateB.getFullYear() &&


### PR DESCRIPTION
Just a minor change to `Heatmap#dateIsEqual()` to fix highlighting for the "week" subdomain.
