### PR TITLE
Adding an onHighlight callback

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -224,6 +224,9 @@ var CalHeatMap = function() {
 		// Callback when clicking on a time block
 		onClick: null,
 
+		// Callback after a date is highlighted
+		onHighlight: null,
+
 		// Callback after painting the empty calendar
 		// Can be used to trigger an API call, once the calendar is ready to be filled
 		afterLoad: null,
@@ -1397,6 +1400,10 @@ CalHeatMap.prototype = {
 			})
 			.call(addStyle)
 		;
+
+		if (options.onHighlight !== null && options.highlight.length) {
+			options.onHighlight(options.highlight);
+		}
 
 		rect.transition().duration(options.animationDuration).select("title")
 			.text(function(d) { return parent.getSubDomainTitle(d); })


### PR DESCRIPTION
I found it useful to have an `onHighlight` callback function that would be run whenever dates are highlighted. I was keeping track of this myself before, but needing to hook in both on init and during update is a little clumsy, this makes the interface a little more straightforward.
