### PR TITLE
Updated bower.json to comply with the specifications

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "d3": ">= v3.0.6"
   },
   "location": "https://github.com/wa0x6e/cal-heatmap",
-  "licence": "MIT",
+  "license": "MIT",
   "ignore": [
     "test/",
     "src/",
@@ -21,10 +21,10 @@
     "karma.conf.js",
     "package.json"
   ],
-  "author": {
+  "authors": [{
     "name": "Wan Qi Chen",
-    "url": "http://www.kamisama.me"
-  },
+    "homepage": "http://www.kamisama.me"
+  }],
   "homepage": "https://github.com/wa0x6e/cal-heatmap",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am using [Webjars](http://www.webjars.org) for a project. `cal-heatmap` is unfortunately not available yet as Webjar but it is possible to create them automatically from a Bower package. However, for it to work, the `bower.json` file describing the component must carefully follow the [specifications for this file](https://github.com/bower/bower.json-spec). In particular, it is sensitive to the `license` field, which is misspelled in the project right now. Updating that and the `authors` entry as this pull request suggests should fix the issues with Webjars and other tools that might rely on Bower.
