### PR TITLE
Constrain to d3 3.x.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "version": "3.6.0",
   "main": ["./cal-heatmap.js", "./cal-heatmap.css"],
   "dependencies": {
-    "d3": ">= v3.0.6"
+    "d3": ">=3.0.6 <4.0.0"
   },
   "location": "https://github.com/wa0x6e/cal-heatmap",
   "license": "MIT",

--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "3.6.0",
   "repository": "wa0x6e/cal-heatmap",
   "dependencies": {
-    "mbostock/d3": ">= 3.0.6"
+    "mbostock/d3": ">=3.0.6 <4.0.0"
   },
   "main": "cal-heatmap.js",
   "scripts": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "test"
   },
   "dependencies": {
-    "d3": ">= v3.0.6"
+    "d3": "^3.0.6"
   },
   "devDependencies": {
     "grunt": "~0.4.5",
@@ -58,7 +58,7 @@
   },
   "jam": {
     "dependencies": {
-      "d3": ">=3.0.6"
+      "d3": "^3.0.6"
     }
   },
   "bugs": "https://github.com/wa0x6e/cal-heatmap/issues",


### PR DESCRIPTION
Fix for #210 and #207. Although there is a workaround of having the client specify a d3 version, this will fix it until the module can be upgraded to d3 4.0.