### PR TITLE
Fix an issue the max color becomes black when legend starts with 0

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -3346,7 +3346,7 @@ Legend.prototype.buildColors = function() {
 
 	if (_legend[0] > 0) {
 		_legend.unshift(0);
-	} else if (_legend[0] < 0) {
+	} else if (_legend[0] <= 0) {
 		// Let's guess the leftmost value, it we have to add one
 		_legend.unshift(_legend[0] - (_legend[_legend.length-1] - _legend[0])/_legend.length);
 	}


### PR DESCRIPTION
For example, when setLegend([0,10,20,30], ["white","blue"]) is called,
color for values >30 is set to black color, instead of blue.
This patch fixes #224.