### PR TITLE
fix dereference undefined when calling cal.update()/cal.highlight()

### DIFF
--- a/src/cal-heatmap.js
+++ b/src/cal-heatmap.js
@@ -1386,7 +1386,7 @@ CalHeatMap.prototype = {
 
 		var rect = svg
 			.selectAll("svg").selectAll("g")
-			.data(function(d) { return parent._domains.get(d); })
+			.data(function(d) { return parent._domains.get(d) || []; })
 		;
 
 		/**


### PR DESCRIPTION
``d3.data`` requires an array and in corner cases (the domain is not visible) the call ``this._domains.get(date)`` returns undefined. This PR updates the call to fall back to an empty array and not throw an exception.
                                                                 
fixes #96 