### PR TITLE
Remove `src` from `package.json` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "Visualization"
   ],
   "files": [
-    "src",
     "dist"
   ],
   "config": {


### PR DESCRIPTION
Including the `src` in the distribution not only adds unnecessary module size, but also causes type validators to flag errors in code unrelated to the top-level project