### PR TITLE
fix(helpers): Add non-null asserts to min/max function usage

### DIFF
--- a/src/helpers/DateHelper.ts
+++ b/src/helpers/DateHelper.ts
@@ -206,8 +206,8 @@ export default class DateHelper {
     start = start.startOf(interval as ManipulateType);
 
     end = end.startOf(interval as ManipulateType);
-    let pivot = dayjs.min(start, end);
-    end = dayjs.max(start, end);
+    let pivot = dayjs.min(start, end)!;
+    end = dayjs.max(start, end)!;
     const result: Timestamp[] = [];
 
     if (!excludeEnd) {


### PR DESCRIPTION
When typechecking my own code, I get the following errors, attached below.
From what I understand, the underlying library is using the spread operator on the input, which itself would error out on an empty array. This PR attempts to fix the type checker issues by simply guarantee-ing that the output is non-null. 
Another potential fix is that we instead spread the input, i.e something like:
```ts
    let pivot = dayjs.min(...[start, end]);
```

![image](https://github.com/wa0x6e/cal-heatmap/assets/48220549/c4336c6e-3245-48bd-ab18-24d9d1ce2153)
