### PR TITLE
fix: fix call signature of `on(...)` to allow a function with arguments

### DIFF
--- a/src/CalHeatmap.ts
+++ b/src/CalHeatmap.ts
@@ -248,7 +248,7 @@ export default class CalHeatmap {
    * @param  {function} Callback function to execute on event trigger
    * @return void
    */
-  on(name: string, fn: () => any): void {
+  on(name: string, fn: (...args: any[]) => any): void {
     this.eventEmitter.on(name, fn);
   }
 


### PR DESCRIPTION
This fixes TypeScript complaining that `cal.on('click', (event, timestamp, value) => ...)` is providing a function that does not match `() => any`.