### PR TITLE
fix(vite): The above dynamic import cannot be analyzed by Vite.

### DIFF
--- a/src/helpers/DateHelper.ts
+++ b/src/helpers/DateHelper.ts
@@ -242,6 +242,6 @@ export default class DateHelper {
 
   // eslint-disable-next-line class-methods-use-this
   loadNodeLocale(userLocale: string): Promise<any> {
-    return import(`dayjs/locale/${userLocale}.js`);
+    return import(/* @vite-ignore */ `dayjs/locale/${userLocale}.js`);
   }
 }


### PR DESCRIPTION
The above dynamic import cannot be analyzed by Vite.
See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ comment inside the import() call to suppress this warning.

<img width="1134" alt="image" src="https://github.com/wa0x6e/cal-heatmap/assets/36953759/303f42fa-74ed-4cae-92d4-94a790c561e4">
