### PR TITLE
feat(types): Add TypeScript definitions for built-in plugins (4.2.4)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -75,6 +75,111 @@ declare namespace CalHeatmap {
     key?: string;
   }
   export type PluginDefinition = [IPluginContructor, Partial<PluginOptions>?];
+
+  // Plugin Options
+
+  export interface LegendOptions extends PluginOptions {
+    enabled: boolean;
+    itemSelector: string | null;
+    label: string | null;
+    width: number;
+  }
+
+  export interface LegendLiteOptions extends PluginOptions {
+    enabled: boolean;
+    itemSelector: string | null;
+    width: number;
+    height: number;
+    radius: number;
+    gutter: number;
+    includeBlank: boolean;
+  }
+
+  export interface PopperOptions {
+    placement: any;
+    modifiers: any[];
+    strategy: any;
+    onFirstUpdate?: any;
+  }
+
+  export interface TooltipOptions extends PluginOptions, PopperOptions {
+    enabled: boolean;
+    text: (
+      timestamp: CalHeatmap.Timestamp,
+      value: number,
+      dayjsDate: dayjs.Dayjs,
+    ) => string;
+  }
+
+  export type ComputedOptions = {
+    radius: number;
+    width: number;
+    height: number;
+    gutter: number;
+    textAlign: TextAlign;
+  };
+
+  export type Padding = [number, number, number, number];
+  export type TextAlign = 'start' | 'middle' | 'end';
+
+  export interface CalendarLabelOptions extends PluginOptions, Partial<ComputedOptions> {
+    enabled: boolean;
+    text: () => string[];
+    padding: Padding;
+  }
+
+  // Built-in plugins
+
+  export class Legend implements IPlugin {
+    constructor(calendar: CalHeatmap);
+    name: string;
+    calendar: CalHeatmap;
+    options: LegendOptions;
+    root: any;
+    shown: boolean;
+    setup(options?: Partial<LegendOptions>): void;
+    paint(): Promise<unknown>;
+    destroy(): Promise<unknown>;
+  }
+
+  export class LegendLite implements IPlugin {
+    constructor(calendar: CalHeatmap);
+    name: string;
+    calendar: CalHeatmap;
+    options: LegendLiteOptions;
+    root: any;
+    shown: boolean;
+    setup(options?: Partial<LegendLiteOptions>): void;
+    paint(): Promise<unknown>;
+    destroy(): Promise<unknown>;
+  }
+
+  export class Tooltip implements IPlugin {
+    constructor(calendar: CalHeatmap);
+    name: string;
+    calendar: CalHeatmap;
+    options: Partial<TooltipOptions>;
+    root: HTMLElement | null;
+    popperInstance: any;
+    popperOptions: any;
+    listenerAttached: boolean;
+    setup(options?: Partial<TooltipOptions>): void;
+    paint(): Promise<unknown>;
+    destroy(): Promise<unknown>;
+  }
+
+  export class CalendarLabel implements IPlugin {
+    constructor(calendar: CalHeatmap);
+    name: string;
+    calendar: CalHeatmap;
+    options: CalendarLabelOptions;
+    root: any;
+    shown: boolean;
+    computedOptions: ComputedOptions;
+    setup(options?: Partial<CalendarLabelOptions>): void;
+    paint(): Promise<unknown>;
+    destroy(): Promise<unknown>;
+  }
 }
 
 declare class CalHeatmap {


### PR DESCRIPTION
Adds TypeScript type definitions for the built-in plugins (Legend, LegendLite, Tooltip, CalendarLabel) in index.d.ts file, addressing https://github.com/wa0x6e/cal-heatmap/issues/520

Note: These type definitions were initially written against release 4.2.4 (commit 815d744).




